### PR TITLE
Subset feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ interval in json
 
 Note: Please use the stable branch, as the master branch contains untested changes.
 Note: autoconf/autoheader must be installed in order to build htslib dependency
-Note: On linux systems, use 'sudo make' rather than 'make'. Also export LD_LIBRARY_PATH="/usr/local/lib" before 
+Note: On linux systems, use 'sudo make' rather than 'make'. Also export LD_LIBRARY_PATH="/usr/local/lib" before
 running so that htslib can be found for dynamic loading.
 
 Usage
@@ -21,6 +21,8 @@ Options:
   -q	qualHistLowerVal [default=1]	The lower value of invalid QUAL value. Any QUAL value less than this will not be counted towards quality histogram
   -Q	qualHistUpperVal [default=200]	The upper value of invalid QUAL value. Any QUAL value greater than this will not be counted towards quality histogram
   -l	logScaleAF [default=false]	    When specified, allele frequency histogram will be in log scale
+  -b	batch [default=false]	    When specified, the statistics will only be outputed a single time at the end of the analysis.
+  -S	subsetsamples [default=false]	    When specified for a multisample vcf the stats will be calculated for each sample independently and the output will be in the form `sampleName.json` with 1 file for each sample.
 
 If no vcf-file is specified, input is then read from stdin
 ```

--- a/README.md
+++ b/README.md
@@ -22,10 +22,8 @@ Options:
   -Q	qualHistUpperVal [default=200]	The upper value of invalid QUAL value. Any QUAL value greater than this will not be counted towards quality histogram
   -l	logScaleAF [default=false]	    When specified, allele frequency histogram will be in log scale
   -b	batch [default=false]	    When specified, the statistics will only be outputed a single time at the end of the analysis.
-<<<<<<< HEAD
   -S	subsetsamples [default=false]	    When specified for a multisample vcf the stats will be calculated for each sample independently and the output will be in the form `sampleName.json` with 1 file for each sample.
-=======
->>>>>>> master
+
 
 If no vcf-file is specified, input is then read from stdin
 ```

--- a/main.cpp
+++ b/main.cpp
@@ -151,8 +151,6 @@ int main(int argc, char* argv[]) {
 	BasicStatsCollector **bsc_arr = (BasicStatsCollector **)malloc(sizeof(BasicStatsCollector) * nsmpl);
 	BasicStatsCollector *bsc;
 	if (subsetSamples) {
-
-	// 	// bsc = new BasicStatsCollector[nsmpl];
 		for (int k=0; k < nsmpl; k++) {
 			bsc_arr[k] = new BasicStatsCollector(qualHistLowerVal, qualHistUpperVal, logScaleAF);
 		}

--- a/main.cpp
+++ b/main.cpp
@@ -196,7 +196,7 @@ int main(int argc, char* argv[]) {
 	if(subsetSamples) {
 		for (int k=0; k<nsmpl; k++) {
 			ofstream myfile;
-			char *sampleName = strcat(hdr->samples[k], ".json");
+			char *sampleName = strcat(hdr->samples[k], ".vcfstats.json");
   			myfile.open (sampleName);
 			printStatsJansson(bsc_arr[k], myfile);
 			myfile.close();

--- a/main.cpp
+++ b/main.cpp
@@ -19,6 +19,8 @@ static struct option getopt_options[] =
 	{"qual-lower-val",	optional_argument,	0, 'q'},
 	{"qual-upper-val",	optional_argument,	0, 'Q'},
 	{"log-scale-af",	optional_argument,	0, 'l'},
+	{"subset-samples",	optional_argument,	0, 'S'},
+	{"batch",	optional_argument,	0, 'b'},
 	{0, 0, 0, 0}
 };
 
@@ -26,8 +28,45 @@ static unsigned int updateRate;
 static unsigned int firstUpdateRate;
 static int qualHistLowerVal;
 static int qualHistUpperVal;
+static bool subsetSamples = false;
+static bool batch = false;
 
-void printStatsJansson(AbstractStatCollector* rootStatCollector);
+void printStatsJansson(AbstractStatCollector* rootStatCollector, ostream& outstream);
+
+bool bcf_gt_is_ref(int gt1, int gt2) {
+	int gt = bcf_alleles2gt(bcf_gt_allele(gt1), bcf_gt_allele(gt2));
+	return ( gt == 0 );
+}
+
+int *bcf_is_refs(bcf_hdr_t* hdr, bcf1_t* var)
+{
+
+	int i, j, ngt, nsmpl = bcf_hdr_nsamples(hdr);
+	int *arr = new int[nsmpl];
+	int32_t *gt_arr = NULL, ngt_arr = 0;
+
+	ngt = bcf_get_genotypes(hdr, var, &gt_arr, &ngt_arr);
+
+	int max_ploidy = ngt/nsmpl;
+	for (i=0; i<nsmpl; i++)
+	{
+		int32_t *ptr = gt_arr + i*max_ploidy;
+		for (j=0; j<max_ploidy; j+=2)
+		{
+			// if true, the sample has smaller ploidy
+			if ( ptr[j]==bcf_int32_vector_end ) break;
+
+			// missing allele
+			if ( bcf_gt_is_missing(ptr[j]) ) continue;
+
+			arr[i] = bcf_gt_is_ref(ptr[0], ptr[1]);
+		}
+	}
+
+	free(gt_arr);
+
+   	return arr;
+}
 
 int main(int argc, char* argv[]) {
 
@@ -41,7 +80,7 @@ int main(int argc, char* argv[]) {
 	int option_index = 0;
 
 	int ch;
-	while((ch = getopt_long (argc, argv, "f:u:q:Q:l", getopt_options, &option_index)) != -1) {
+	while((ch = getopt_long (argc, argv, "f:u:q:Q:l:b:S", getopt_options, &option_index)) != -1) {
 		switch(ch) {
 			case 0:
 				break;
@@ -67,6 +106,12 @@ int main(int argc, char* argv[]) {
 				break;
 			case 'l':
 				logScaleAF = true;
+				break;
+			case 'S':
+				subsetSamples = true;
+				break;
+			case 'b':
+				batch = true;
 				break;
 			default:
 				break;
@@ -96,42 +141,77 @@ int main(int argc, char* argv[]) {
 		exit(1);
 	}
 
-	BasicStatsCollector *bsc = new BasicStatsCollector(qualHistLowerVal, qualHistUpperVal, logScaleAF);
-
 	unsigned long totalVariants = 0;
 
 	bcf_hdr_t* hdr = bcf_hdr_read(fp);
 	bcf1_t* line = bcf_init();
+	int nsmpl = bcf_hdr_nsamples(hdr);
+
+	BasicStatsCollector **bsc_arr = (BasicStatsCollector **)malloc(sizeof(BasicStatsCollector) * nsmpl);
+	BasicStatsCollector *bsc;
+	if (subsetSamples) {
+
+	// 	// bsc = new BasicStatsCollector[nsmpl];
+		for (int k=0; k < nsmpl; k++) {
+			bsc_arr[k] = new BasicStatsCollector(qualHistLowerVal, qualHistUpperVal, logScaleAF);
+		}
+	} else {
+		bsc = new BasicStatsCollector(qualHistLowerVal, qualHistUpperVal, logScaleAF);
+	}
 
 	while(bcf_read(fp, hdr, line) == 0) {
 
 		// Unpack alternates and info block
-		if (bcf_unpack(line, BCF_UN_STR) != 0) {
+		if (bcf_unpack(line, BCF_UN_ALL) != 0) {
 			std::cerr<<"Error unpacking"<<std::endl;
 		}
 
-		bsc->processVariant(hdr, line);
-		
+
+		if (subsetSamples) {
+			int *isRefs = bcf_is_refs(hdr, line);
+			for (int k=0; k < nsmpl; k++) {
+				if (!isRefs[k]) {
+					bsc_arr[k]->processVariant(hdr, line);
+				}
+			}
+
+		} else {
+			bsc->processVariant(hdr, line);
+		}
+
+
 		totalVariants++;
 
-		if((totalVariants > 0 && totalVariants % updateRate == 0) ||
-				(firstUpdateRate > 0 && totalVariants >= firstUpdateRate)) {
+		if( (!subsetSamples || !batch) && ((totalVariants > 0 && totalVariants % updateRate == 0) ||
+				(firstUpdateRate > 0 && totalVariants >= firstUpdateRate))) {
 
-			printStatsJansson(bsc);
+			printStatsJansson(bsc, cout);
 
 			// disable first update after it has been fired.
 			if(firstUpdateRate > 0) firstUpdateRate = 0;
 		}
 	}
 
-	printStatsJansson(bsc);
+	if(subsetSamples) {
+		for (int k=0; k<nsmpl; k++) {
+			ofstream myfile;
+			char *sampleName = strcat(hdr->samples[k], ".json");
+  			myfile.open (sampleName);
+			printStatsJansson(bsc_arr[k], myfile);
+			myfile.close();
+		}
+	} else {
+		printStatsJansson(bsc, cout);
+	}
+
 
 	delete bsc;
+	free(bsc_arr);
 
 	return 0;
 }
 
-void printStatsJansson(AbstractStatCollector* rootStatCollector) {
+void printStatsJansson(AbstractStatCollector* rootStatCollector, ostream& outstream) {
 
 	// Create the root object that contains everything
 	json_t * j_root = json_object();
@@ -140,7 +220,7 @@ void printStatsJansson(AbstractStatCollector* rootStatCollector) {
 	rootStatCollector->appendJson(j_root);
 
 	// Dump the json
-	cout<<json_dumps(j_root, JSON_COMPACT | JSON_ENSURE_ASCII | JSON_PRESERVE_ORDER)<<";"<<endl;
+	outstream<<json_dumps(j_root, JSON_COMPACT | JSON_ENSURE_ASCII | JSON_PRESERVE_ORDER)<<";"<<endl;
 
 	json_decref(j_root);
 }


### PR DESCRIPTION
This is for consideration as the -S (subset sample) flag changes some otherwise expected behavior when used. The main change is that instead of the results outputing to stdout, each sample in the vcf will get it's own vcfstats file following the convention `sampleName.vcfstats.json`.